### PR TITLE
Revise to use commandTurnSpeed

### DIFF
--- a/src/screens/crew1/singlePilotScreen.cpp
+++ b/src/screens/crew1/singlePilotScreen.cpp
@@ -160,24 +160,14 @@ void SinglePilotScreen::onDraw(sp::RenderTarget& renderer)
 
 void SinglePilotScreen::onUpdate()
 {
-    if (my_spaceship && isVisible())
+    if (my_spaceship && my_player_info && isVisible())
     {
-        static bool was_turning = false;
+        auto current_turn_request = keys.helms_turn_right.getValue() - keys.helms_turn_left.getValue();
 
-        auto transform = my_spaceship.getComponent<sp::Transform>();
-        if (transform)
+        if (current_turn_request != turn_request)
         {
-            auto angle = (keys.helms_turn_right.getValue() - keys.helms_turn_left.getValue()) * 5.0f;
-            if (angle != 0.0f)
-            {
-                was_turning = true;
-                my_player_info->commandTargetRotation(transform->getRotation() + angle);
-            }
-            else if (was_turning)
-            {
-                was_turning = false;
-                my_player_info->commandTargetRotation(transform->getRotation());
-            }
+            turn_request = current_turn_request;
+            my_player_info->commandTurnSpeed(turn_request);
         }
         
         if (keys.weapons_enemy_next_target.getDown())

--- a/src/screens/crew1/singlePilotScreen.h
+++ b/src/screens/crew1/singlePilotScreen.h
@@ -27,7 +27,9 @@ private:
     GuiRotationDial* missile_aim;
     GuiMissileTubeControls* tube_controls;
     GuiToggleButton* lock_aim;
+
     bool drag_rotate;
+    float turn_request = 0.0f;
 public:
     SinglePilotScreen(GuiContainer* owner);
 

--- a/src/screens/crew4/tacticalScreen.cpp
+++ b/src/screens/crew4/tacticalScreen.cpp
@@ -141,24 +141,14 @@ void TacticalScreen::onDraw(sp::RenderTarget& renderer)
 
 void TacticalScreen::onUpdate()
 {
-    if (my_spaceship && isVisible())
+    if (my_spaceship && my_player_info && isVisible())
     {
-        static bool was_turning = false;
+        auto current_turn_request = keys.helms_turn_right.getValue() - keys.helms_turn_left.getValue();
 
-        auto transform = my_spaceship.getComponent<sp::Transform>();
-        if (transform)
+        if (current_turn_request != turn_request)
         {
-            auto angle = (keys.helms_turn_right.getValue() - keys.helms_turn_left.getValue()) * 5.0f;
-            if (angle != 0.0f)
-            {
-                was_turning = true;
-                my_player_info->commandTargetRotation(transform->getRotation() + angle);
-            }
-            else if (was_turning)
-            {
-                was_turning = false;
-                my_player_info->commandTargetRotation(transform->getRotation());
-            }
+            turn_request = current_turn_request;
+            my_player_info->commandTurnSpeed(turn_request);
         }
 
         if (keys.weapons_enemy_next_target.getDown())

--- a/src/screens/crew4/tacticalScreen.h
+++ b/src/screens/crew4/tacticalScreen.h
@@ -24,7 +24,9 @@ private:
     GuiRotationDial* missile_aim;
     GuiMissileTubeControls* tube_controls;
     GuiToggleButton* lock_aim;
+
     bool drag_rotate;
+    float turn_request = 0.0f;
 public:
     TacticalScreen(GuiContainer* owner);
 

--- a/src/screens/crew6/helmsScreen.cpp
+++ b/src/screens/crew6/helmsScreen.cpp
@@ -134,25 +134,14 @@ void HelmsScreen::onDraw(sp::RenderTarget& renderer)
 
 void HelmsScreen::onUpdate()
 {
-    if (my_spaceship && isVisible())
+    if (my_spaceship && my_player_info && isVisible())
     {
-        static bool was_turning = false;
+        auto current_turn_request = keys.helms_turn_right.getValue() - keys.helms_turn_left.getValue();
 
-        auto transform = my_spaceship.getComponent<sp::Transform>();
-
-        if (transform)
+        if (current_turn_request != turn_request)
         {
-            auto angle = (keys.helms_turn_right.getValue() - keys.helms_turn_left.getValue()) * 5.0f;
-            if (angle != 0.0f)
-            {
-                was_turning = true;
-                my_player_info->commandTargetRotation(transform->getRotation() + angle);
-            }
-            else if (was_turning)
-            {
-                was_turning = false;
-                my_player_info->commandTargetRotation(transform->getRotation());
-            }
+            turn_request = current_turn_request;
+            my_player_info->commandTurnSpeed(turn_request);
         }
     }
 }

--- a/src/screens/crew6/helmsScreen.h
+++ b/src/screens/crew6/helmsScreen.h
@@ -19,6 +19,8 @@ private:
     GuiLabel* heading_hint;
     GuiCombatManeuver* combat_maneuver;
     GuiDockingButton* docking_button;
+
+    float turn_request = 0.0f;
 public:
     HelmsScreen(GuiContainer* owner);
 


### PR DESCRIPTION
Attempt to use `commandTurnSpeed` instead of `commandTargetRotation` to reduce the number of network requests when using keyboard controls to rotate a ship on Helms, Tactical, and Single Pilot.

Rest `commandTurnSpeed` upon client disconnection, to prevent a ship from rotating endlessly if the key is down upon disconnect. This might be followed with additional resets to other navigation features, like impulse and warp, that might also be stuck in an undesired position upon disconnect.)